### PR TITLE
refactor(server,listener)!: Let caller handle exceptions on server open

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Listener.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Listener.java
@@ -1,4 +1,5 @@
 package eu.chargetime.ocpp;
+import java.io.IOException;
 /*
    ChargeTime.eu - Java-OCA-OCPP
 
@@ -26,7 +27,8 @@ package eu.chargetime.ocpp;
 */
 
 public interface Listener {
-  void open(String hostname, int port, ListenerEvents listenerEvents);
+  void open(String hostname, int port, ListenerEvents listenerEvents)
+        throws IOException;
 
   void close();
 

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Server.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Server.java
@@ -28,6 +28,7 @@ package eu.chargetime.ocpp;
 import eu.chargetime.ocpp.feature.Feature;
 import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -73,7 +74,8 @@ public class Server {
    * @param port the port number of the server.
    * @param serverEvents Callback handler for server specific events.
    */
-  public void open(String hostname, int port, ServerEvents serverEvents) {
+  public void open(String hostname, int port, ServerEvents serverEvents)
+        throws IOException {
 
     listener.open(
         hostname,

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ServerTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ServerTest.java
@@ -6,6 +6,7 @@ import eu.chargetime.ocpp.*;
 import eu.chargetime.ocpp.feature.Feature;
 import eu.chargetime.ocpp.model.Request;
 import eu.chargetime.ocpp.model.SessionInformation;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.Before;
@@ -61,7 +62,7 @@ public class ServerTest {
   @Mock private IPromiseRepository promiseRepository;
 
   @Before
-  public void setup() {
+  public void setup() throws IOException {
     UUID sessionId = UUID.randomUUID();
     when(request.validate()).thenReturn(true);
     when(session.getSessionId()).thenReturn(sessionId);
@@ -80,7 +81,7 @@ public class ServerTest {
   }
 
   @Test
-  public void newSession_serverIsListening_sessionIsAccepted() {
+  public void newSession_serverIsListening_sessionIsAccepted() throws IOException {
     // Given
     server.open(LOCALHOST, PORT, serverEvents);
 
@@ -92,7 +93,7 @@ public class ServerTest {
   }
 
   @Test
-  public void newSession_serverIsListening_callbackWithIndex0() {
+  public void newSession_serverIsListening_callbackWithIndex0() throws IOException  {
     // Given
     server.open(LOCALHOST, PORT, serverEvents);
 
@@ -117,7 +118,8 @@ public class ServerTest {
   }
 
   @Test
-  public void handleRequest_callsFeatureHandleRequest() throws UnsupportedFeatureException {
+  public void handleRequest_callsFeatureHandleRequest() 
+    throws UnsupportedFeatureException, IOException {
     // Given
     server.open(LOCALHOST, PORT, serverEvents);
     listenerEvents.newSession(session, information);

--- a/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/JSONTestServer.java
+++ b/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/JSONTestServer.java
@@ -30,6 +30,7 @@ import eu.chargetime.ocpp.feature.profile.Profile;
 import eu.chargetime.ocpp.feature.profile.ServerCoreProfile;
 import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
@@ -75,7 +76,7 @@ public class JSONTestServer implements IServerAPI {
   }
 
   @Override
-  public void open(String host, int port, ServerEvents serverEvents) {
+  public void open(String host, int port, ServerEvents serverEvents) throws IOException {
     logger.info("Feature repository: {}", featureRepository);
     server.open(host, port, serverEvents);
   }

--- a/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/SOAPTestServer.java
+++ b/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/SOAPTestServer.java
@@ -30,6 +30,7 @@ import eu.chargetime.ocpp.feature.profile.Profile;
 import eu.chargetime.ocpp.feature.profile.ServerCoreProfile;
 import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
+import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 
@@ -58,7 +59,7 @@ public class SOAPTestServer implements IServerAPI {
   }
 
   @Override
-  public void open(String host, int port, ServerEvents serverEvents) {
+  public void open(String host, int port, ServerEvents serverEvents) throws IOException {
     server.open(host, port, serverEvents);
   }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/IServerAPI.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/IServerAPI.java
@@ -30,13 +30,15 @@ import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
+import java.io.IOException;
 
 public interface IServerAPI {
   void addFeatureProfile(Profile profile);
 
   void closeSession(UUID session);
 
-  void open(String host, int port, ServerEvents serverEvents);
+  void open(String host, int port, ServerEvents serverEvents)
+        throws IOException;
 
   void close();
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/JSONServer.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/JSONServer.java
@@ -143,7 +143,8 @@ public class JSONServer implements IServerAPI {
   }
 
   @Override
-  public void open(String host, int port, ServerEvents serverEvents) {
+  public void open(String host, int port, ServerEvents serverEvents)
+        throws IOException {
     logger.info("Feature repository: {}", featureRepository);
     server.open(host, port, serverEvents);
   }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPServer.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPServer.java
@@ -29,6 +29,7 @@ import eu.chargetime.ocpp.feature.profile.Profile;
 import eu.chargetime.ocpp.feature.profile.ServerCoreProfile;
 import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
+import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 
@@ -58,7 +59,8 @@ public class SOAPServer implements IServerAPI {
   }
 
   @Override
-  public void open(String host, int port, ServerEvents serverEvents) {
+  public void open(String host, int port, ServerEvents serverEvents)
+        throws IOException {
     server.open(host, port, serverEvents);
   }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceListener.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceListener.java
@@ -55,20 +55,16 @@ public class WebServiceListener implements Listener {
   }
 
   @Override
-  public void open(String hostname, int port, ListenerEvents listenerEvents) {
+  public void open(String hostname, int port, ListenerEvents listenerEvents) throws IOException {
     events = listenerEvents;
     fromUrl = String.format("http://%s:%d", hostname, port);
-    try {
-      server = HttpServer.create(new InetSocketAddress(hostname, port), 0);
-      server.createContext("/", new WSHttpHandler(WSDL_CENTRAL_SYSTEM, new WSHttpEventHandler()));
+    server = HttpServer.create(new InetSocketAddress(hostname, port), 0);
+    server.createContext("/", new WSHttpHandler(WSDL_CENTRAL_SYSTEM, new WSHttpEventHandler()));
 
-      server.setExecutor(java.util.concurrent.Executors.newCachedThreadPool());
-      server.start();
+    server.setExecutor(java.util.concurrent.Executors.newCachedThreadPool());
+    server.start();
 
-      closed = false;
-    } catch (IOException e) {
-      logger.warn("open() failed", e);
-    }
+    closed = false;
   }
 
   @Override

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/IServerAPI.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/IServerAPI.java
@@ -28,6 +28,7 @@ package eu.chargetime.ocpp;
 import eu.chargetime.ocpp.feature.Feature;
 import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
+import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 
@@ -36,7 +37,8 @@ public interface IServerAPI {
 
   void closeSession(UUID session);
 
-  void open(String host, int port, ServerEvents serverEvents);
+  void open(String host, int port, ServerEvents serverEvents)
+    throws IOException;
 
   void close();
 

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/JSONServer.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/JSONServer.java
@@ -130,7 +130,8 @@ public class JSONServer implements IServerAPI {
   }
 
   @Override
-  public void open(String host, int port, ServerEvents serverEvents) {
+  public void open(String host, int port, ServerEvents serverEvents) 
+    throws IOException {
     logger.info("Feature repository: {}", featureRepository);
     server.open(host, port, serverEvents);
   }


### PR DESCRIPTION
- Open blocks until complete for WebSocket server, or throws SocketException if socket can't be bound
- Open blocks until complete for SOAP server, or throws various IOExceptions including SocketException if socket can't be bound


Without this change, a server can't know reliably whether a call to `open` succeeded or not. 

@chris13524 When you accept this PR, I'd like to open it with the upstream project.